### PR TITLE
findOrCreate performance

### DIFF
--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -305,7 +305,8 @@ export default class Model {
         const { outBinds } = await this._nessie!.executeMany(sql, {
             binds,
             bindDefs,
-            commit: true
+            commit: true,
+            connection: options.connection
         });
         return this.parseOutBinds(outBinds as any, metadata);
     }

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -315,7 +315,8 @@ export default class Model {
         this.initCheck();
         const [created] = await this.bulkCreate([values], {
             attributes: options.attributes,
-            ignoreDuplicates: options.ignoreDuplicate
+            ignoreDuplicates: options.ignoreDuplicate,
+            connection: options.connection
         });
         return created ?? null;
     }

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -41,6 +41,7 @@ import {
     ModelQueryDestroyOptions,
     ModelQueryUpdateOptions,
     ModelQueryWhereData,
+    ModelUpdateOptions,
     SyncOptions
 } from "./utils/typedefs";
 
@@ -419,10 +420,11 @@ export default class Model {
         return this.parseOutBinds([outBinds as any], metadata);
     }
 
-    async update(values: ModelQueryAttributeData, options: ModelQueryAttributesOptions = {}) {
+    async update(values: ModelQueryAttributeData, options: ModelUpdateOptions = {}) {
         const [updated] = await this.model.update(values, {
             where: { ROWID: this.rowId },
-            attributes: options.attributes
+            attributes: options.attributes,
+            connection: options.connection
         });
         this.dataValues = updated.dataValues;
         return this;

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -29,6 +29,7 @@ import {
     FindAllModelOptions,
     FindOneModelOptions,
     FindOrCreateModelOptions,
+    FindRowIdModelOptions,
     FormattedModelAssociations,
     FormattedModelAttributes,
     ModelAttributes,
@@ -369,9 +370,11 @@ export default class Model {
         return first ?? null;
     }
 
-    static async findByRowId(rowId: string) {
+    static async findByRowId(rowId: string, options: FindRowIdModelOptions = {}) {
         return this.findOne({
-            where: { ROWID: rowId }
+            where: { ROWID: rowId },
+            attributes: options.attributes,
+            connection: options.connection
         });
     }
 

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -358,7 +358,10 @@ export default class Model {
         if (typeof options.limit === "number") {
             sqlData.push(`FETCH NEXT ${Math.floor(options.limit)} ROWS ONLY`);
         }
-        const results: Result<any> = await this._nessie!.execute(sqlData.join(" "), { bindParams });
+        const results: Result<any> = await this._nessie!.execute(sqlData.join(" "), {
+            bindParams,
+            connection: options.connection
+        });
         return results.rows!.map(row => new this(results.metaData!, row));
     }
 

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -435,7 +435,8 @@ export default class Model {
         const [where, bindParams] = this.parseQueryAttributeDataSql(options.where);
         const { rowsAffected } = await this._nessie!.execute(`DELETE FROM "${this.tableName}" WHERE ${where}`, {
             bindParams,
-            commit: true
+            commit: true,
+            connection: options.connection
         });
         return rowsAffected ?? 0;
     }

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -25,6 +25,7 @@ import {
     AttributeData,
     BuiltModelBulkQuery,
     ColumnValue,
+    ConnectionOptions,
     FindAllModelOptions,
     FindOneModelOptions,
     FindOrCreateModelOptions,
@@ -37,9 +38,9 @@ import {
     ModelInitOptions,
     ModelQueryAttributeData,
     ModelQueryAttributesOptions,
+    ModelQueryDestroyOptions,
     ModelQueryUpdateOptions,
     ModelQueryWhereData,
-    ModelQueryWhereOptions,
     SyncOptions
 } from "./utils/typedefs";
 
@@ -427,7 +428,7 @@ export default class Model {
         return this;
     }
 
-    static async destroy(options: ModelQueryWhereOptions) {
+    static async destroy(options: ModelQueryDestroyOptions) {
         this.initCheck();
         const [where, bindParams] = this.parseQueryAttributeDataSql(options.where);
         const { rowsAffected } = await this._nessie!.execute(`DELETE FROM "${this.tableName}" WHERE ${where}`, {
@@ -437,10 +438,11 @@ export default class Model {
         return rowsAffected ?? 0;
     }
 
-    async destroy() {
+    async destroy(options: ConnectionOptions = {}) {
         if (!this._destroyed) {
             await this.model.destroy({
-                where: { ROWID: this.rowId }
+                where: { ROWID: this.rowId },
+                connection: options.connection
             });
             this._destroyed = true;
         }

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -39,7 +39,6 @@ import {
     ModelDropOptions,
     ModelInitOptions,
     ModelQueryAttributeData,
-    ModelQueryAttributesOptions,
     ModelQueryDestroyOptions,
     ModelQueryUpdateOptions,
     ModelQueryWhereData,

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -415,7 +415,8 @@ export default class Model {
         const [metadata, returningSql, bindDefs] = this.parseReturningSql(options.attributes, bindParams.length);
         const { outBinds } = await this._nessie!.execute(`UPDATE "${this.tableName}" SET ${valuesSql} WHERE ${where} ${returningSql}`, {
             bindParams: bindParams.concat(bindDefs),
-            commit: true
+            commit: true,
+            connection: options.connection
         });
         return this.parseOutBinds([outBinds as any], metadata);
     }

--- a/lib/Nessie.ts
+++ b/lib/Nessie.ts
@@ -5,6 +5,7 @@ import {
     Pool
 } from "oracledb"
 import Model from "./Model";
+import cleanupConnection from "./utils/cleanupConnection";
 import {
     ConnectionOptions,
     DefineModelOptions,
@@ -127,11 +128,5 @@ export default class Nessie {
     async close(drainTime?: number) {
         await (isNaN(drainTime!) ? this._pool?.close() : this._pool?.close(drainTime));
         this._pool = null;
-    }
-}
-
-async function cleanupConnection(connection: Connection, connectionOption?: Connection) {
-    if (!connectionOption) {
-        await connection.close();
     }
 }

--- a/lib/Nessie.ts
+++ b/lib/Nessie.ts
@@ -1,5 +1,4 @@
 import {
-    Connection,
     createPool,
     initOracleClient,
     Pool

--- a/lib/utils/cleanupConnection.ts
+++ b/lib/utils/cleanupConnection.ts
@@ -1,0 +1,7 @@
+import { Connection } from "oracledb";
+
+export default async function cleanupConnection(connection: Connection, connectionOption?: Connection) {
+    if (!connectionOption) {
+        await connection.close();
+    }
+}

--- a/lib/utils/typedefs.d.ts
+++ b/lib/utils/typedefs.d.ts
@@ -103,7 +103,9 @@ type FindOneModelOptions = ModelQueryAttributesOptions & { where?: ModelQueryWhe
 
 type FindAllModelOptions = FindOneModelOptions & { limit?: number };
 
-type ModelQueryUpdateOptions = ModelQueryWhereOptions & ModelQueryAttributesOptions;
+type ModelUpdateOptions = ConnectionOptions & ModelQueryAttributesOptions;
+
+type ModelQueryUpdateOptions = ModelUpdateOptions & ModelQueryWhereOptions;
 
 interface ModelQueryAttributeData {
     [key: string]: ColumnValue;

--- a/lib/utils/typedefs.d.ts
+++ b/lib/utils/typedefs.d.ts
@@ -78,7 +78,7 @@ type ModelDropOptions = ConnectionOptions & { cascade?: boolean };
 
 type ModelQueryAttributesOptions = { attributes?: Array<string> };
 
-type ModelCreateOptions = ModelQueryAttributesOptions & { ignoreDuplicate?: boolean };
+type ModelCreateOptions = ConnectionOptions & ModelQueryAttributesOptions & { ignoreDuplicate?: boolean };
 
 type BuiltModelBulkQuery = {
     metadata: Array<Metadata<any>>;

--- a/lib/utils/typedefs.d.ts
+++ b/lib/utils/typedefs.d.ts
@@ -110,3 +110,5 @@ interface ModelQueryAttributeData {
 }
 
 type FindOrCreateModelOptions = ModelQueryUpdateOptions & { defaults?: ModelQueryAttributeData };
+
+type ModelQueryDestroyOptions = ConnectionOptions & ModelQueryWhereOptions;

--- a/lib/utils/typedefs.d.ts
+++ b/lib/utils/typedefs.d.ts
@@ -99,9 +99,11 @@ interface ModelQueryWhereData {
 
 type ModelQueryWhereOptions = { where: ModelQueryWhereData };
 
-type FindOneModelOptions = ModelQueryAttributesOptions & { where?: ModelQueryWhereData };
+type FindOneModelOptions = ConnectionOptions & ModelQueryAttributesOptions & { where?: ModelQueryWhereData };
 
 type FindAllModelOptions = FindOneModelOptions & { limit?: number };
+
+type FindRowIdModelOptions = ConnectionOptions & ModelQueryAttributesOptions;
 
 type ModelUpdateOptions = ConnectionOptions & ModelQueryAttributesOptions;
 

--- a/lib/utils/typedefs.d.ts
+++ b/lib/utils/typedefs.d.ts
@@ -87,7 +87,7 @@ type BuiltModelBulkQuery = {
     bindDefs: Array<BindDefinition>
 };
 
-type ModelBulkCreateOptions = ModelQueryAttributesOptions & { ignoreDuplicates?: boolean };
+type ModelBulkCreateOptions = ConnectionOptions & ModelQueryAttributesOptions & { ignoreDuplicates?: boolean };
 
 interface ModelQueryWhereOperatorData {
     [key: Operators]: ColumnValue;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,13 @@
-import { BindDefinition, BindParameters, Connection, InitialiseOptions, Pool, PoolAttributes, Result, Results } from "oracledb";
+import {
+    BindDefinition,
+    BindParameters,
+    Connection,
+    InitialiseOptions,
+    Pool,
+    PoolAttributes,
+    Result,
+    Results
+} from "oracledb";
 
 export enum DataTypes {
     STRING = "VARCHAR(255)",
@@ -96,9 +105,9 @@ type ModelDropOptions = ConnectionOptions & { cascade?: boolean };
 
 type ModelQueryAttributesOptions = { attributes?: Array<string> };
 
-type ModelCreateOptions = ModelQueryAttributesOptions & { ignoreDuplicate?: boolean };
+type ModelCreateOptions = ConnectionOptions & ModelQueryAttributesOptions & { ignoreDuplicate?: boolean };
 
-type ModelBulkCreateOptions = ModelQueryAttributesOptions & { ignoreDuplicates?: boolean };
+type ModelBulkCreateOptions = ConnectionOptions & ModelQueryAttributesOptions & { ignoreDuplicates?: boolean };
 
 interface ModelQueryWhereOperatorData {
     [key: Operators]: ColumnValue;
@@ -110,17 +119,23 @@ interface ModelQueryWhereData {
 
 type ModelQueryWhereOptions = { where: ModelQueryWhereData };
 
-type FindOneModelOptions = ModelQueryAttributesOptions & { where?: ModelQueryWhereData };
+type FindOneModelOptions = ConnectionOptions & ModelQueryAttributesOptions & { where?: ModelQueryWhereData };
 
 type FindAllModelOptions = FindOneModelOptions & { limit?: number };
 
-type ModelQueryUpdateOptions = ModelQueryWhereOptions & ModelQueryAttributesOptions;
+type FindRowIdModelOptions = ConnectionOptions & ModelQueryAttributesOptions;
+
+type ModelUpdateOptions = ConnectionOptions & ModelQueryAttributesOptions;
+
+type ModelQueryUpdateOptions = ModelUpdateOptions & ModelQueryWhereOptions;
 
 interface ModelQueryAttributeData {
     [key: string]: ColumnValue;
 }
 
 type FindOrCreateModelOptions = ModelQueryUpdateOptions & { defaults?: ModelQueryAttributeData };
+
+type ModelQueryDestroyOptions = ConnectionOptions & ModelQueryWhereOptions;
 
 export class Model {
     static readonly tableName: string;
@@ -142,11 +157,11 @@ export class Model {
     static bulkCreate(values: Array<ModelQueryAttributeData>, options?: ModelBulkCreateOptions): Promise<Array<Model>>;
     static findAll(options?: FindAllModelOptions): Promise<Array<Model>>;
     static findOne(options?: FindOneModelOptions): Promise<Model | null>;
-    static findByRowId(rowId: string): Promise<Model | null>;
+    static findByRowId(rowId: string, options?: FindRowIdModelOptions): Promise<Model | null>;
     static findOrCreate(options: FindOrCreateModelOptions): Promise<[Model, boolean]>;
     static update(values: ModelQueryAttributeData, options: ModelQueryUpdateOptions): Promise<Array<Model>>;
-    static destroy(options: ModelQueryWhereOptions): Promise<number>;
+    static destroy(options: ModelQueryDestroyOptions): Promise<number>;
 
-    update(values: ModelQueryAttributeData, options?: ModelQueryAttributesOptions): Promise<this>;
-    destroy(): Promise<void>;
+    update(values: ModelQueryAttributeData, options?: ModelUpdateOptions): Promise<this>;
+    destroy(options?: ConnectionOptions): Promise<void>;
 }


### PR DESCRIPTION
- implement `connection` option in more methods
- use single connection for whole findOrCreate "transaction"
- also implements missing `attributes` option in findByRowId